### PR TITLE
Generic styles for input/button/select

### DIFF
--- a/src/components/media/SearchMedia.tsx
+++ b/src/components/media/SearchMedia.tsx
@@ -60,6 +60,7 @@ const SearchMedia = (): ReactElement => {
             id="media-searchbar"
             type="search"
             placeholder="Search"
+            autoComplete="off"
             onChange={(e) => {
               setSearchTitle(e.target.value);
 

--- a/src/components/ui/useDropdown.tsx
+++ b/src/components/ui/useDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 
 // Styles
-import { MediaSelector } from '../../styles/components/select';
+import { Select } from '../../styles/components/select';
 // Media
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretDown, faSearch } from '@fortawesome/free-solid-svg-icons';
@@ -17,7 +17,7 @@ const useDropdown = (
   const Dropdown = (): ReactElement => (
     <>
       <label htmlFor={id}>{label}</label>
-      <MediaSelector
+      <Select
         id={id}
         value={state}
         onChange={(e) => setState(e.target.value)}
@@ -28,7 +28,7 @@ const useDropdown = (
             {item.toLowerCase().replace(/^\w/, (c) => c.toUpperCase())}
           </option>
         ))}
-      </MediaSelector>
+      </Select>
       <FontAwesomeIcon icon={faCaretDown} />
     </>
   );

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -17,6 +17,10 @@ const GlobalStyles = createGlobalStyle`
 		--secondary-text: #ddd;
 		--placeholder-text: #ccc;
 		--links-text: #ff8c7c;
+
+		// Focus highlights
+		--focus-highlight: #ff8c7c;
+		--unfocused-highlights: #ff8c7c00;
 		
 		// Border-Radius
 		--rounded-input: 7px;
@@ -59,28 +63,6 @@ const GlobalStyles = createGlobalStyle`
 	}
 
 	// Generic styling for various elements
-	input,
-	button,
-	select {
-		appearance: none!important;
-		margin: 0;
-		padding: 0;
-		border-radius: var(--rounded-input);
-		border: none;
-		background-color: var(--foreground-background-color);
-		color: var(--main-text);
-
-
-		&::placeholder {
-			text-transform: capitalize;
-			color: var(--placeholder-text);
-			opacity: 1;
-		}
-		&:focus {
-			border: 2px solid var(--links-text);
-			outline: none;
-		}
-	}
 	option {
 		text-transform: capitalize;
 	}

--- a/src/styles/components/button.tsx
+++ b/src/styles/components/button.tsx
@@ -1,22 +1,13 @@
 import styled from 'styled-components';
+import generalStyleInteractions from './generalStylesInteractions';
 
 export const Button = styled.button`
-  height: 3.5em;
-  @media screen and (max-width: 600px) {
-    font-size: var(--font-me);
-    height: 3.2em;
-  }
+  ${generalStyleInteractions}
 `;
 
 export const AddEntryButton = styled(Button)`
   background-color: var(--cta-accept-color);
   user-select: none;
-  &:hover:not(:active) {
-    filter: brightness(110%);
-  }
-  &:active {
-    filter: brightness(90%);
-  }
 `;
 
 export default Button;

--- a/src/styles/components/generalStylesInteractions.tsx
+++ b/src/styles/components/generalStylesInteractions.tsx
@@ -1,0 +1,33 @@
+export const generalStyleInteractions = `
+appearance: none!important;
+margin: 0;
+padding: 0;
+border-radius: var(--rounded-input);
+border: 4px solid var(--unfocused-highlights);
+background-color: var(--foreground-background-color);
+color: var(--main-text);
+
+&::placeholder {
+  text-transform: capitalize;
+  color: var(--placeholder-text);
+  opacity: 1;
+}
+&:focus {
+  border: 4px solid var(--focus-highlight);
+  outline: none;
+}
+&:hover:not(:active) {
+  filter: brightness(110%);
+}
+&:active {
+  filter: brightness(90%);
+}
+
+height: 3.5em;
+  @media screen and (max-width: 600px) {
+    font-size: var(--font-me);
+    height: 3.2em;
+  }
+`;
+
+export default generalStyleInteractions;

--- a/src/styles/components/input.tsx
+++ b/src/styles/components/input.tsx
@@ -1,11 +1,8 @@
 import styled from 'styled-components';
+import generalStylesInteractions from './generalStylesInteractions';
 
 const Input = styled.input`
-  height: 3.5em;
-  @media screen and (max-width: 600px) {
-    font-size: var(--font-me);
-    height: 3.2em;
-  }
+  ${generalStylesInteractions}
 `;
 
 export default Input;

--- a/src/styles/components/select.tsx
+++ b/src/styles/components/select.tsx
@@ -1,13 +1,11 @@
 import styled from 'styled-components';
+import generalStylesInteractions from './generalStylesInteractions';
 
-const Select = styled.select`
-  height: 3.5em;
-  @media screen and (max-width: 600px) {
-    font-size: var(--font-me);
-    height: 3.2em;
-  }
+// Media
+import { faCaretDown, faSearch } from '@fortawesome/free-solid-svg-icons';
+
+export const Select = styled.select`
+  ${generalStylesInteractions}
 `;
-
-export const MediaSelector = styled(Select)``;
 
 export default Select;

--- a/src/styles/searchMedia/SearchMediaLayout.tsx
+++ b/src/styles/searchMedia/SearchMediaLayout.tsx
@@ -80,9 +80,6 @@ const SearchMediaLayout = styled.div`
 
   .media-type-dropdown {
     position: relative;
-    background-color: var(--foreground-background-color);
-    border-radius: var(--rounded-input);
-    box-sizing: border-box;
     transition-property: transform;
     transition-duration: 0.1s;
 
@@ -109,12 +106,6 @@ const SearchMediaLayout = styled.div`
     }
 
     &:focus-within {
-      select {
-        padding-left: 38px;
-        border: 2px solid var(--links-text);
-        outline: none;
-        border-radius: var(--rounded-input) var(--rounded-input) 0 0;
-      }
       svg {
         color: var(--main-text) !important;
       }
@@ -122,9 +113,6 @@ const SearchMediaLayout = styled.div`
   }
   .searchbox {
     position: relative;
-    background-color: var(--foreground-background-color);
-    border-radius: var(--rounded-input);
-    box-sizing: border-box;
 
     input {
       width: 100%;
@@ -145,12 +133,6 @@ const SearchMediaLayout = styled.div`
     }
     &:focus-within {
       input {
-        padding-left: 38px;
-        border: 2px solid var(--links-text);
-        outline: none;
-        padding-top: 0px;
-        padding-bottom: 0px;
-
         &:hover:not(:focus) {
           filter: brightness(110%);
         }


### PR DESCRIPTION
Made a generic constant with general styling for all input types that can then be overwritten in specific scenarios instead.

Made the media dropdown use a generic dropdown styling instead (not much changed either way)

Changed the method for displaying borders when focusing on an element. Now it hides it by default by making it transparent.

Made the search bar not display autocompletion suggestions (they're based on previous searches so they're more annoying than helpful).