### PR TITLE
Use media-type in Search

### DIFF
--- a/src/components/media/SearchMedia.tsx
+++ b/src/components/media/SearchMedia.tsx
@@ -51,12 +51,12 @@ const SearchMedia = (): ReactElement => {
 
   // Debounce search so it won't fire immediately
   const debouncedSearch = useCallback(
-    debounce((nextValue) => {
+    debounce((nextValue: string, mediaType: MediaTypeEnum) => {
       // Only fire if there's a search query
       const searchTitleVariables: SearchMediaByTitleQueryVariables = {
         first: 15,
         title: nextValue,
-        media_type: media as MediaTypeEnum,
+        media_type: mediaType,
       };
 
       if (nextValue) {
@@ -74,9 +74,10 @@ const SearchMedia = (): ReactElement => {
   // Handle the debouncing
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value: nextValue } = event.target;
+    const mediaType = media as MediaTypeEnum;
     // Lowercase search query for caching purposes
     setSearchTitle(nextValue.toLowerCase());
-    debouncedSearch(nextValue.toLowerCase());
+    debouncedSearch(nextValue.toLowerCase(), mediaType);
   };
 
   return (

--- a/src/components/media/SearchMedia.tsx
+++ b/src/components/media/SearchMedia.tsx
@@ -74,6 +74,8 @@ const SearchMedia = (): ReactElement => {
   // Handle the debouncing
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value: nextValue } = event.target;
+    // HACK: we want to most likely modify the useDropDown to accept some type of way to modify
+    // the onChange.
     const mediaType = media as MediaTypeEnum;
     // Lowercase search query for caching purposes
     setSearchTitle(nextValue.toLowerCase());


### PR DESCRIPTION
Potential fix for integrating search with media_type and debounce. Not sure if there is a better way because this will not trigger if you only change the type.

The other way to fix this would be to modify the useDropdown hook to either accept, or return a callback that we can extend additional methods onto. That will be a bit more complicated and I'd need to do some research so most likely not worth doing at this point.